### PR TITLE
feat: 参加者リストが一覧で見れるコンポーネントの作成

### DIFF
--- a/pages/components.tsx
+++ b/pages/components.tsx
@@ -87,7 +87,10 @@ const Component: NextPage = () => {
           <Heading size="lg">MemberList</Heading>
           <Card variant="filled">
             <CardBody>
-              <MemberList title={"参加者リスト"} memberName={exampleNameList} />
+              <MemberList
+                title={"参加者リスト"}
+                memberNameList={exampleNameList}
+              />
             </CardBody>
           </Card>
 

--- a/pages/components.tsx
+++ b/pages/components.tsx
@@ -13,10 +13,19 @@ import {
 
 import { HSpacer, VSpacer } from "@/components/common/Spacer";
 import { CustomInput } from "@/components/CustomInput";
+import { MemberList } from "@/components/MemberList";
 import { TempComponent } from "@/components/TempComponent";
 
 const Component: NextPage = () => {
   const [text, setText] = useState("");
+  const exampleNameList = [
+    "ふかむーる",
+    "ふかみん",
+    "ふかむー",
+    "ふかめも",
+    "KJ",
+  ];
+
   return (
     <>
       <VStack>
@@ -70,6 +79,15 @@ const Component: NextPage = () => {
                 setText={setText}
               />
               <p>{text}</p>
+            </CardBody>
+          </Card>
+
+          {/*MemberList*/}
+          <VSpacer size={8} />
+          <Heading size="lg">MemberList</Heading>
+          <Card variant="filled">
+            <CardBody>
+              <MemberList title={"参加者リスト"} memberName={exampleNameList} />
             </CardBody>
           </Card>
 

--- a/src/components/MemberList.tsx
+++ b/src/components/MemberList.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { ListItem, Text, UnorderedList } from "@chakra-ui/react";
+
+import { VSpacer } from "@/components/common/Spacer";
+
+type Props = {
+  title: string;
+  memberName: Array<string>;
+};
+
+export const MemberList = ({ title, memberName }: Props) => {
+  const nameList = memberName.map((member) => <li key={member}>{member}</li>);
+
+  return (
+    <>
+      <Text fontSize="xl">{title}</Text>
+      <VSpacer size={8} />
+      <UnorderedList>
+        <ListItem fontSize="2xl">{nameList}</ListItem>
+      </UnorderedList>
+    </>
+  );
+};

--- a/src/components/MemberList.tsx
+++ b/src/components/MemberList.tsx
@@ -6,18 +6,22 @@ import { VSpacer } from "@/components/common/Spacer";
 
 type Props = {
   title: string;
-  memberName: Array<string>;
+  memberNameList: Array<string>;
 };
 
-export const MemberList = ({ title, memberName }: Props) => {
-  const nameList = memberName.map((member) => <li key={member}>{member}</li>);
-
+export const MemberList = ({ title, memberNameList }: Props) => {
   return (
     <>
       <Text fontSize="xl">{title}</Text>
       <VSpacer size={8} />
       <UnorderedList>
-        <ListItem fontSize="2xl">{nameList}</ListItem>
+        {memberNameList.map((memberName, i) => {
+          return (
+            <ListItem key={i} fontSize="2x1">
+              {memberName}
+            </ListItem>
+          );
+        })}
       </UnorderedList>
     </>
   );


### PR DESCRIPTION
## 🔨 変更内容

- 参加者のリストが一覧で見れるコンポーネントの作成をしました。

## 📸 スクリーンショット

## 📢 この PR に含まないこと

- 参加者の登録は考えておらず、サンプルデータを使っています。

## 💡 レビューの観点

### PR 作成者のチェック項目

- [x] セルフレビュー
- [x] CI/CD がすべて pass している
- [x] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [x] コードレビュー
- [x] コンポーネント内でmapを使用してelementにしてるけど何か他にいい方法がありそう？
- [x] 一覧表示についてのレビュー

## ✅ 解決するイシュー

- close #22 

## 🤝 関連するイシュー

- #22
