### PR TITLE
ルーム作成者のみがゲームを開始できるように UI を調整

### DIFF
--- a/pages/create-room.tsx
+++ b/pages/create-room.tsx
@@ -47,9 +47,7 @@ const CreateRoom: NextPage = () => {
               router.push({
                 pathname: "/wait",
                 query: {
-                  username: nickname,
-                  avatarIcon: avatarIndex,
-                  isRoomCreate: true,
+                  isRoomCreate: "true",
                 },
               });
             }}

--- a/pages/wait.tsx
+++ b/pages/wait.tsx
@@ -1,4 +1,5 @@
 import type { NextPage } from "next";
+import { useRouter } from "next/router";
 import React from "react";
 
 import { Button, Center, VStack } from "@chakra-ui/react";
@@ -9,6 +10,8 @@ import { VSpacer } from "@/components/common/Spacer";
 import { MemberList } from "@/components/MemberList";
 
 const Wait: NextPage = () => {
+  const router = useRouter();
+
   return (
     <>
       <PageBackIcon pass={"/create-room"} />
@@ -22,16 +25,18 @@ const Wait: NextPage = () => {
             memberNameList={["aaaaa", "bbbbb", "ccccc"]}
           />
           <VSpacer size={24} />
-          <Button
-            h={"60px"}
-            w={"270px"}
-            colorScheme="blue"
-            // onClick={() => {
-            //   router.push("");
-            // }}
-          >
-            ゲーム開始
-          </Button>
+          {router.query && router.query.isRoomCreate == "true" && (
+            <Button
+              h={"60px"}
+              w={"270px"}
+              colorScheme="blue"
+              // onClick={() => {
+              //   router.push("");
+              // }}
+            >
+              ゲーム開始
+            </Button>
+          )}
         </VStack>
       </Center>
     </>


### PR DESCRIPTION
## 🔨 変更内容

- ルーム作成者のみがゲームを開始できるように UI を調整した

## 💡 レビューの観点

### PR 作成者のチェック項目

- [x] セルフレビュー
- [x] CI/CD がすべて pass している
- [x] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー
- [ ] `create-room` から `/wait` へ行った場合には、「ゲーム開始ボタン」が表示され、`join-room` から `/wait` へ行った場合にはボタンが表示されないことを確認する

## ✅ 解決するイシュー

- close #75

## 🤝 関連するイシュー

- #75
